### PR TITLE
Fix template slug handling in ResolveSiteMiddleware

### DIFF
--- a/html/app/Http/Middleware/ResolveSiteMiddleware.php
+++ b/html/app/Http/Middleware/ResolveSiteMiddleware.php
@@ -86,9 +86,8 @@ class ResolveSiteMiddleware
     app()->instance('theme_settings', $settings);
 
     // Register theme view namespaces
-    $templateSlug = $template['slug'];
-    $themePath    = resource_path("views/templates/{$templateSlug}");
-    $basePath     = resource_path('views/templates/default');
+    $themePath = resource_path("views/templates/{$templateSlug}");
+    $basePath  = resource_path('views/templates/default');
 
     View::replaceNamespace('theme', [$themePath, $basePath]);
     View::replaceNamespace('themeBase', [$basePath]);


### PR DESCRIPTION
## Summary
- Avoid assuming template is an array when registering theme view namespaces

## Testing
- `php -l app/Http/Middleware/ResolveSiteMiddleware.php`
- `composer test` *(fails: Failed opening required '/workspace/web-templates/html/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689ec97013ac8325a0358e120578472f